### PR TITLE
Use nvidia/cuda:8.0-cudnn6-devel-ubuntu16.04 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:8.0-cudnn5-devel-ubuntu16.04
+FROM nvidia/cuda:8.0-cudnn6-devel-ubuntu16.04
 MAINTAINER MAINTAINER David Manthey <david.manthey@kitware.com>
 
 


### PR DESCRIPTION
This is needed for tensorflow 1.3.0